### PR TITLE
Correct prototype for host call functions in tests

### DIFF
--- a/test/rlparse.d/actparams.cc
+++ b/test/rlparse.d/actparams.cc
@@ -14,18 +14,18 @@ using std::cout;
 using std::endl;
 
 extern "C" {
-	colm_value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, str_t *_machine, str_t *_action );
-	colm_value_t cc_action_params_insert( struct colm_program *prg, tree_t **sp, str_t *_machine, str_t *_action );
+	colm_value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, colm_value_t _machine, colm_value_t _action );
+	colm_value_t cc_action_params_insert( struct colm_program *prg, tree_t **sp, colm_value_t _machine, colm_value_t _action );
 }
 
 typedef set<string> Set;
 typedef map< string, Set > Map;
 static Map machineMap;
 
-value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, str_t *_machine, str_t *_action )
+value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, value_t _machine, value_t _action )
 {
-	string machine( _machine->value->data, _machine->value->length );
-	string action( _action->value->data, _action->value->length );
+	string machine( ( (str_t *) _machine )->value->data, ( (str_t *) _machine )->value->length );
+	string action( ( (str_t *) _action )->value->data, ( (str_t *) _action )->value->length );
 
 	// cout << "cc_action_params_find " << machine << " " << action << " ";
 
@@ -42,10 +42,10 @@ value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, str_t *_ma
 	return (value_t) res;
 }
 
-value_t cc_action_params_insert( struct colm_program *prg, tree_t **sp, str_t *_machine, str_t *_action )
+value_t cc_action_params_insert( struct colm_program *prg, tree_t **sp, value_t _machine, value_t _action )
 {
-	string machine( _machine->value->data, _machine->value->length );
-	string action( _action->value->data, _action->value->length );
+	string machine( ( (str_t *) _machine )->value->data, ( (str_t *) _machine )->value->length );
+	string action( ( (str_t *) _action )->value->data, ( (str_t *) _action )->value->length );
 
 	// cout << "cc_action_params_insert " << machine << " " << action << endl;
 

--- a/test/trans.d/actparams.cc
+++ b/test/trans.d/actparams.cc
@@ -14,18 +14,18 @@ using std::cout;
 using std::endl;
 
 extern "C" {
-	colm_value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, str_t *_machine, str_t *_action );
-	colm_value_t cc_action_params_insert( struct colm_program *prg, tree_t **sp, str_t *_machine, str_t *_action );
+	colm_value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, colm_value_t _machine, colm_value_t _action );
+	colm_value_t cc_action_params_insert( struct colm_program *prg, tree_t **sp, colm_value_t _machine, colm_value_t _action );
 }
 
 typedef set<string> Set;
 typedef map< string, Set > Map;
 static Map machineMap;
 
-value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, str_t *_machine, str_t *_action )
+value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, value_t _machine, value_t _action )
 {
-	string machine( _machine->value->data, _machine->value->length );
-	string action( _action->value->data, _action->value->length );
+	string machine( ( (str_t *) _machine )->value->data, ( (str_t *) _machine )->value->length );
+	string action( ( (str_t *) _action )->value->data, ( (str_t *) _action )->value->length );
 
 	// cout << "cc_action_params_find " << machine << " " << action << " ";
 
@@ -42,10 +42,10 @@ value_t cc_action_params_find( struct colm_program *prg, tree_t **sp, str_t *_ma
 	return (value_t) res;
 }
 
-value_t cc_action_params_insert( struct colm_program *prg, tree_t **sp, str_t *_machine, str_t *_action )
+value_t cc_action_params_insert( struct colm_program *prg, tree_t **sp, value_t _machine, value_t _action )
 {
-	string machine( _machine->value->data, _machine->value->length );
-	string action( _action->value->data, _action->value->length );
+	string machine( ( (str_t *) _machine )->value->data, ( (str_t *) _machine )->value->length );
+	string action( ( (str_t *) _action )->value->data, ( (str_t *) _action )->value->length );
 
 	// cout << "cc_action_params_insert " << machine << " " << action << endl;
 


### PR DESCRIPTION
While the parameters declared in test/trans.d/ragel.lm: https://github.com/adrian-thurston/colm/blob/fc61ecb3a22b89864916ec538eaf04840e7dd6b5/test/trans.d/ragel.lm#L4-L8 and test/rlparse.d/ragel.lm: https://github.com/adrian-thurston/colm/blob/fc61ecb3a22b89864916ec538eaf04840e7dd6b5/test/rlparse.d/ragel.lm#L4-L8 are indeed strings, all parameters for host calls declared in Colm source files are converted to value_t by Compiler::writeHostCall: https://github.com/adrian-thurston/colm/blob/fc61ecb3a22b89864916ec538eaf04840e7dd6b5/src/compiler.cc#L1109-L1117.

This led to warnings when compiling with LTO. Correcting the prototypes and inserting the appropriate casts makes everything compile without warnings. The test suite still passes the same on my x86_64 machine.
