### PR TITLE
Fix out-of-bounds memcpy

### DIFF
--- a/src/pdarun.c
+++ b/src/pdarun.c
@@ -382,7 +382,8 @@ static void report_parse_error( program_t *prg, tree_t **sp, struct pda_run *pda
 	/* If there are no error points on record assume the error occurred at the
 	 * beginning of the stream. */
 	if ( deepest == 0 )  {
-		error_head = string_alloc_full( prg, "<input>:1:1: parse error", 32 );
+		const char *parse_error_string = "<input>:1:1: parse error";
+		error_head = string_alloc_full( prg, parse_error_string, strlen( parse_error_string ) );
 		error_head->location = location_allocate( prg );
 		error_head->location->line = 1;
 		error_head->location->column = 1;


### PR DESCRIPTION
`memcpy` in `string_alloc_full` was copying 32 bytes, while the string is only 25 bytes including the terminating null byte.

Also, since this is a string literal, there is no need to actually copy it. Just allocating a head is enough if I'm reading the code correctly. This was also found by building with LTO enabled.
