### PR TITLE
Delete test cases in out-of-tree build

### DIFF
--- a/test/aapl.d/Makefile.am
+++ b/test/aapl.d/Makefile.am
@@ -105,6 +105,9 @@ CLEANFILES = gentests
 
 clean-local:
 	rm -Rf working
+	if test '$(builddir)' != '$(srcdir)'; then \
+		rm -f *.exp; \
+	fi
 
 check-local:
 	if test '$(builddir)' != '$(srcdir)'; then \

--- a/test/colm.d/Makefile.am
+++ b/test/colm.d/Makefile.am
@@ -189,6 +189,9 @@ CLEANFILES = gentests
 
 clean-local:
 	rm -Rf working
+	if test '$(builddir)' != '$(srcdir)'; then \
+		rm -f *.lm *.lmi *.in; \
+	fi
 
 check-local:
 	if test '$(builddir)' != '$(srcdir)'; then \

--- a/test/rlhc.d/Makefile.am
+++ b/test/rlhc.d/Makefile.am
@@ -1093,6 +1093,10 @@ CLEANFILES = rlhc.c
 
 clean-local:
 	rm -Rf working
+	if test '$(builddir)' != '$(srcdir)'; then \
+		rm -Rf case; \
+		rm -f gentests; \
+	fi
 
 check-local:
 	if test '$(builddir)' != '$(srcdir)'; then \

--- a/test/rlparse.d/Makefile.am
+++ b/test/rlparse.d/Makefile.am
@@ -45,6 +45,10 @@ CLEANFILES = parse.c if.h if.cc commit.cc
 
 clean-local:
 	rm -Rf working
+	if test '$(builddir)' != '$(srcdir)'; then \
+		rm -Rf case; \
+		rm -f gentests; \
+	fi
 
 check-local:
 	if test '$(builddir)' != '$(srcdir)'; then \

--- a/test/trans.d/Makefile.am
+++ b/test/trans.d/Makefile.am
@@ -380,6 +380,10 @@ CLEANFILES = trans.c
 
 clean-local:
 	rm -Rf working
+	if test '$(builddir)' != '$(srcdir)'; then \
+		rm -Rf case; \
+		rm -f gentests; \
+	fi
 
 check-local:
 	if test '$(builddir)' != '$(srcdir)'; then \


### PR DESCRIPTION
While 7e3709188833f72ca7a0808942d3a9da6464675f deleted too much, the fix in f9708db3960b95457c1efaf092efc65d3b486c9f actually deleted too little.

The cleaning is now guarded by the same condition as the initial linking or copying.
