### PR TITLE
Install runtests as a script

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = . aapl.d colm.d rlhc.d rlparse.d trans.d
 
 check_SCRIPTS = subject.mk subject.sh
 
-pkgdata_DATA = runtests
+pkgdata_SCRIPTS = runtests
 
 EXTRA_DIST = subject.mk.in subject.sh.in runtests
 


### PR DESCRIPTION
This installs it executable, so ragel can actually use it.
