### PR TITLE
if buildDir is not set with -B, try to find a default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -375,7 +375,7 @@ AC_ARG_WITH(crack,
 SED_SUBST="$SED_SUBST -e 's|@CRACK_BIN@|${CRACK_BIN}|g'"
 
 AC_SUBST(CRACK_BIN)
-	
+
 dnl Skip bootstrap process and build using an existing version of colm. Allows us to
 dnl break colm without breaking the build of colm.
 dnl 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,7 +54,8 @@ common_CFLAGS = \
 	-Wall \
 	-DINCLUDEDIR='"$(includedir)"' \
 	-DLIBDIR='"$(libdir)"' \
-	-DABS_TOP_BUILDDIR='"$(abs_top_builddir)"'
+	-DABS_TOP_BUILDDIR='"$(abs_top_builddir)"' \
+	-DABS_BUILDDIR='"$(abs_builddir)"'
 
 libprog_a_SOURCES = \
 	buffer.h bytecode.h colm.h debug.h dotgen.h fsmcodegen.h fsmgraph.h \
@@ -214,4 +215,3 @@ colm-wrap: colm-wrap.sh
 loadinit.cc: gen/if1.h
 loadboot2.cc: gen/if2.h
 loadcolm.cc: gen/if3.h
-

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,8 @@ endif
 common_CFLAGS = \
 	-Wall \
 	-DINCLUDEDIR='"$(includedir)"' \
-	-DLIBDIR='"$(libdir)"'
+	-DLIBDIR='"$(libdir)"' \
+	-DABS_TOP_BUILDDIR='"$(abs_top_builddir)"'
 
 libprog_a_SOURCES = \
 	buffer.h bytecode.h colm.h debug.h dotgen.h fsmcodegen.h fsmgraph.h \

--- a/src/main.cc
+++ b/src/main.cc
@@ -683,10 +683,29 @@ bool readCheck( const char *fn )
 	return result;
 }
 
+void defaultBuildDir()
+{
+	if ( buildDir != 0 )
+		return;
+
+	const char *ldlp = getenv("LD_LIBRARY_PATH");
+	if ( ldlp != 0 ) {
+		size_t len_atbd = strlen(ABS_TOP_BUILDDIR);
+
+		if ( strlen(ldlp) > len_atbd &&
+				memcmp( ldlp, ABS_TOP_BUILDDIR "/", len_atbd+1) == 0 )
+		{
+			buildDir = ABS_TOP_BUILDDIR;
+		}
+	}
+}
+    
 /* Main, process args and call yyparse to start scanning input. */
 int main(int argc, const char **argv)
 {
 	processArgs( argc, argv );
+
+	defaultBuildDir();
 
 	if ( verbose )
 		gblActiveRealm = 0xffffffff;

--- a/src/main.cc
+++ b/src/main.cc
@@ -688,14 +688,23 @@ void defaultBuildDir()
 	if ( buildDir != 0 )
 		return;
 
-	const char *ldlp = getenv("LD_LIBRARY_PATH");
-	if ( ldlp != 0 ) {
-		size_t len_atbd = strlen(ABS_TOP_BUILDDIR);
+	struct stat self;
+	if ( stat( "/proc/self/exe", &self ) == 0 )
+	{
+		struct stat colm;
 
-		if ( strlen(ldlp) > len_atbd &&
-				memcmp( ldlp, ABS_TOP_BUILDDIR "/", len_atbd+1) == 0 )
+		if ( stat ( ABS_BUILDDIR "/" LT_OBJDIR "colm", &colm ) == 0 &&
+				self.st_dev == colm.st_dev && self.st_ino == colm.st_ino )
 		{
 			buildDir = ABS_TOP_BUILDDIR;
+			return;
+		}
+
+		if ( stat ( ABS_BUILDDIR "/colm", &colm ) == 0 &&
+				self.st_dev == colm.st_dev && self.st_ino == colm.st_ino )
+		{
+			buildDir = ABS_TOP_BUILDDIR;
+			return;
 		}
 	}
 }


### PR DESCRIPTION
When running from the build directory, if one forgets to give -B, and colm was
previously installed at the current prefix, colm programs will build against
the installed version, not the local source tree. This won't be immediately
obvious and could lead to confusion during development.

To prevent this, try to find the buildDir if one is not given. The tests can
continue to specify the buildDir with -B, which is the most safe way.

The buildDir is defaulted by testing the buildDir known at compile time against
LD_LIBRARY_PATH. Libtool on ubuntu 20.04 will place the buildDir at the head of
LD_LIBRARY_PATH. It seems likely that it would do this on all systems, making
it a seemingly good test.