### PR TITLE
Add Github Actions testing and release

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,0 +1,54 @@
+on:
+  release:
+    types:
+      - created
+
+name: Upload Release Assets
+
+jobs:
+  assets:
+    name: Upload Release Assets
+    strategy:
+      matrix:
+        include:
+         - name: linux
+           os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Extract version tag
+        id: version
+        run: echo ::set-output name=value::$(echo ${{ github.ref }} | cut -f 3 -d / )
+
+      - name: Build colm
+        run: |
+          set -ex
+          ZIPDIR=colm-${{ steps.version.outputs.value }}
+          mkdir $ZIPDIR
+          CFLAGS="-flto --target=x86_64-unknown-linux-musl -static -O3"
+          CXXFLAGS="$CFLAGS"
+          LDFLAGS="$CFLAGS"
+          bash ./autogen.sh
+          ./configure --prefix=$ZIPDIR CC=clang CXX=clang++ CFLAGS="$CFLAGS" CXXFLAGS="$CXXFLAGS" LDFLAGS="$LDFLAGS"
+          make -j$(nproc)
+          make install
+
+          ls -al $ZIPDIR
+          ls -al $ZIPDIR/bin
+          ls -al $ZIPDIR/lib
+
+          LD_LIBRARY_PATH=$ZIPDIR/lib $ZIPDIR/bin/colm --version
+
+          tar vczf colm-${{matrix.name}}-${{ steps.version.outputs.value }}.tgz $ZIPDIR
+          md5sum colm-${{matrix.name}}-${{ steps.version.outputs.value }}.tgz
+
+      - name: Upload asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: colm-${{matrix.name}}-${{ steps.version.outputs.value }}.tgz
+          name: ${{ steps.version.outputs.value }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    tags:
+    - '[0-9]+.*'
+
+name: Create release
+
+jobs:
+  release:
+    name: Create release
+    if: github.repository_owner == 'adrian-thurston'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version tag
+        id: version
+        run: echo ::set-output name=value::$(echo ${{ github.ref }} | cut -f 4 -d /)
+
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          branch: master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Build and test
+
+on:
+  pull_request:
+  schedule:
+    - cron:  '0 5 * * *'
+
+jobs: 
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cc: gcc
+            cxx: g++
+          - cc: clang
+            cxx: clang++
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: build
+      run: |
+          bash ./autogen.sh
+          ./configure CC=${{ matrix.cc }} CXX=${{ matrix.cxx }}
+          make -j2 test


### PR DESCRIPTION
This PR adds actions to GitHub Actions to this repository to handle automatically testing and releasing this package.

My primary goal is the releases; testing is just a nice benefit. When a commit tagged with `x.x.x` is pushed to `master`, a copy of Colm is built and then pushed as a GitHub Release. The goal of this is to make it easier to not only just download and use `colm`, but to be able to automatically install `colm` in CI through something like [`install-action`](https://github.com/taiki-e/install-action)

@adrian-thurston I can add the manual GH Actions files, but it's up to you to provide a GitHub token it can use to make a release.