### PR TITLE
autogen: Support LIBTOOLIZE environment variable

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,10 +4,10 @@ set -x
 
 case `uname` in
 	Darwin)
-		glibtoolize --quiet --copy --force
+		${LIBTOOLIZE:-glibtoolize} --quiet --copy --force
 		;;
 	*)
-		libtoolize --quiet --copy --force
+		${LIBTOOLIZE:-libtoolize} --quiet --copy --force
 	;;
 esac
 
@@ -15,4 +15,3 @@ aclocal
 autoheader
 automake --foreign --add-missing
 autoconf
-


### PR DESCRIPTION
Currently autogen looks for libtoolize in PATH, but in hermetic builds it may not be. This allows you to set the correct path from env.